### PR TITLE
Update build.yml

### DIFF
--- a/config-step-3-build-local/build.yml
+++ b/config-step-3-build-local/build.yml
@@ -1,6 +1,6 @@
 ---
 apiVersion: kbld.k14s.io/v1alpha1
-kind: Sources
+kind: Config
 sources:
 - image: docker.io/dkalinin/k8s-simple-app
   path: .


### PR DESCRIPTION
might be more idiomatic (as of version 0.28.0) to use `kind: Config` over `kind: Sources` ?